### PR TITLE
Change package ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository serves to host the HL7® FHIR® Technical Comitee developed FHIR
 
 Refer to the IG template in your implementation guide (ig.ini) with:
 ```
-template = at.fhir.ig.template#current
+template = hl7.at.fhir.template#current
 ```
 
 * Provide [packages-list.json](https://wiki.hl7.org/index.php?title=FHIR_IG_PackageList_doco) in input/pagecontent directory
@@ -18,5 +18,4 @@ template = at.fhir.ig.template#current
 ## Examples
 * [Austrian FHIR® Implementation Guides](https://fhir.hl7.at/)
 
-The publishing is done fully automatically after every successful merge to master. 
- 
+The publishing is done fully automatically after every successful merge to master.

--- a/package-list.json
+++ b/package-list.json
@@ -1,8 +1,8 @@
 {
-  "package-id": "at.fhir.ig.template",
+  "package-id": "hl7.at.fhir.template",
   "title": "Austrian FHIR® IG Base Template",
-  "introduction": "Austrian FHIR® IG Base Template",
-  "canonical": "http://build.fhir.org/ig/HL7Austria/at-fhir-ig-template",
+  "introduction": "For use by anyone in the Austrian domain",
+  "canonical": "http://fhir.org/templates/hl7.at.fhir.template",
   "list": [
     {
       "version": "current",

--- a/package-list.json
+++ b/package-list.json
@@ -10,6 +10,14 @@
       "path": "http://build.fhir.org/ig/HL7Austria/at-fhir-ig-template/",
       "status": "ci-build",
       "current": true
+    },
+    {
+      "version": "0.0.1",
+      "desc": "First release",
+      "path": "http://fhir.org/templates/hl7.at.fhir.template/0.0.1",
+      "status": "release",
+      "sequence": "Publications",
+      "date": "2022-08-31"
     }
   ]
 }

--- a/package/package.json
+++ b/package/package.json
@@ -1,10 +1,10 @@
 ﻿{
-  "name": "at.fhir.ig.template",
+  "name": "hl7.at.fhir.template",
   "type": "fhir.template",
   "license": "CC0-1.0",
   "description": "Austrian FHIR® IG Base Template - for use by anyone in the Austrian domain",
   "author": "http://fhir.hl7.at/",
-  "canonical": "http://build.fhir.org/ig/HL7Austria/at-fhir-ig-template/",
+  "canonical": "http://fhir.org/templates/hl7.at.fhir.template",
   "version": "0.0.1",
   "base": "fhir.base.template",
   "dependencies": {


### PR DESCRIPTION
Based on https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Template.20not.20found and on the decision of the TC FHIR (https://collab.hl7.at/display/BAL/2022-06-23+TC+FHIR+Call) the package ID of this template should be changed.