### PR TITLE
Remove feedback form include

### DIFF
--- a/includes/fragment-pageend.html
+++ b/includes/fragment-pageend.html
@@ -93,8 +93,6 @@ if(window.location.hash != "") {
 <script>anchors.options.visible = 'hover'
 anchors.add()</script>
 
-{% include fragment-feedback_form.html %}
-
 <!-- Analytics Below
 ================================================== -->
 </body>


### PR DESCRIPTION
The same error as described here (https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/.E2.9C.94.20Could.20not.20locate.20the.20included.20file.20fragment-feedback_form) occurs when using this template.